### PR TITLE
clarify definition

### DIFF
--- a/academia-entity-category.md
+++ b/academia-entity-category.md
@@ -12,10 +12,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 2. Definition
 ----------------
 
-An identity provider MUST NOT be annotated with the academia entity category unless it is being operated
-* by or
-* on behalf of and by contract with
-at least one organisation represented by a legal entity in good standing in the community of other academic institutions and fulfills at least one of the criteria below:
+An identity provider MUST NOT be annotated with the academia entity category unless the identity provider is being operated by (or on behalf of and by contract with) at least one organisation, represented by a legal entity in good standing in the community of other academic institutions, that fulfills at least one of the criteria below:
 
 1. the organization is dedicated to education and research and which grants academic degrees at level 6 (or higher) according to ISCED 2011 [ISCED] or equivalent internationally recognized academic degree levels.
 2. the organization is a research library or archive


### PR DESCRIPTION
Proposed clarification for the definition statement:
- "it" -> "the identity provider"
- "by or" on its own bullet is unclear, so combine bullets into a single sentence, using parentheses and commas for clarity
